### PR TITLE
Updating Old Skill ID

### DIFF
--- a/GW2Minion/SkillManagerProfiles/Engineer.sm
+++ b/GW2Minion/SkillManagerProfiles/Engineer.sm
@@ -1405,29 +1405,6 @@ local tbl =
 		},
 		
 		{
-			activationtime = 0,
-			condition_luacode = "return true",
-			conditions = 
-			{
-				
-				{
-					
-					{
-						operator = 1,
-						target = 1,
-						uid = "CombatState",
-					}, 
-					casttarget = 2,
-				},
-			},
-			id = 17260,
-			instantcast = true,
-			requireslos = true,
-			setsattackrange = true,
-			skillpaletteuid = "Engi_Flamethrower",
-		},
-		
-		{
 			activationtime = 0.5,
 			condition_luacode = "return true",
 			conditions = 
@@ -1850,29 +1827,6 @@ local tbl =
 				},
 			},
 			id = 6164,
-			requireslos = true,
-			setsattackrange = false,
-			skillpaletteuid = "Engineer",
-		},
-		
-		{
-			activationtime = 0,
-			condition_luacode = "return true",
-			conditions = 
-			{
-				
-				{
-					
-					{
-						operator = 1,
-						target = 1,
-						uid = "CombatState",
-					}, 
-					casttarget = 2,
-				},
-			},
-			id = 5975,
-			instantcast = true,
 			requireslos = true,
 			setsattackrange = false,
 			skillpaletteuid = "Engineer",

--- a/GW2Minion/SkillManagerProfiles/Engineer.sm
+++ b/GW2Minion/SkillManagerProfiles/Engineer.sm
@@ -1831,7 +1831,31 @@ local tbl =
 			setsattackrange = false,
 			skillpaletteuid = "Engineer",
 		},
-		
+
+		{
+			activationtime = 0,
+			condition_luacode = "return true",
+			conditions = 
+			{
+
+				{
+
+					{
+						operator = 1,
+						target = 1,
+						uid = "CombatState",
+					}, 
+					casttarget = 2,
+				},
+			},
+			id = 5970,
+			instantcast = true,
+			requireslos = true,
+			setsattackrange = false,
+			skillpaletteuid = "Engineer",
+		},
+
+
 		{
 			activationtime = 0,
 			condition_luacode = "return true",

--- a/GW2Minion/SkillManagerProfiles/Engineer.sm
+++ b/GW2Minion/SkillManagerProfiles/Engineer.sm
@@ -1855,7 +1855,6 @@ local tbl =
 			skillpaletteuid = "Engineer",
 		},
 
-
 		{
 			activationtime = 0,
 			condition_luacode = "return true",

--- a/GW2Minion/SkillManagerProfiles/Guardian.sm
+++ b/GW2Minion/SkillManagerProfiles/Guardian.sm
@@ -1546,7 +1546,7 @@ local tbl =
 					casttarget = 1,
 				},
 			},
-			id = 15834,
+			id = 9087,
 			instantcast = false,
 			requireslos = true,
 			setsattackrange = true,


### PR DESCRIPTION
Will prevent a error in the console upon loading the SM profile.